### PR TITLE
Add Spring Security dependency

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -44,6 +44,10 @@
             <artifactId>spring-boot-starter-cache</artifactId>
         </dependency>
         <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-security</artifactId>
+        </dependency>
+        <dependency>
             <groupId>com.github.ben-manes.caffeine</groupId>
             <artifactId>caffeine</artifactId>
         </dependency>


### PR DESCRIPTION
The pull request introduces the `spring-boot-starter-security` dependency into the `pom.xml` file to enable Spring Security in the project. There are no additional changes or modifications beyond this dependency addition.